### PR TITLE
use chrome.tabs.executeScript instead of chrome.tabs.update

### DIFF
--- a/extension_1_0_8/buildMenu.js
+++ b/extension_1_0_8/buildMenu.js
@@ -136,7 +136,7 @@ function invokeBookmarklet(node)
 	var code = node.url.split("%20").join(" ");	
 	if (code.indexOf("javascript:")==0) {	
 		chrome.tabs.getSelected( null, function(myTab){
-				chrome.tabs.update(myTab.id, { url:code });
+				chrome.tabs.executeScript(myTab.id, { code:code });
 			} 
 		);
 	}


### PR DESCRIPTION
SpellBookがchromeウェブストアから削除され困っていたので有り難く利用させていただいてます。
Chrome v71.0.3578.98で動かなくなっていたので適当に修正しました。とりあえず動いているようです。